### PR TITLE
✨update / 미래편지 작성 컴포넌트 분리 후 조건부 렌더링, 모바일 시안 적용

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    domains: ['pzyuqsztorznxejhknhd.supabase.co']
+  }
+};
 
 export default nextConfig;

--- a/src/app/letter/page.tsx
+++ b/src/app/letter/page.tsx
@@ -5,7 +5,6 @@ import LetterForm from '@/components/letterComponents/LetterForm';
 const LetterPage = () => {
   return (
     <div>
-      <h1>편지페이지</h1>
       <LetterForm />
     </div>
   );

--- a/src/components/letterComponents/CalendarStep.tsx
+++ b/src/components/letterComponents/CalendarStep.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+type CalendarStepProps = {
+  sendAt: string;
+  setSendAt: (date: string) => void;
+  onNext: () => void;
+};
+
+const CalendarStep = ({ sendAt, setSendAt, onNext }: CalendarStepProps) => {
+  return (
+    <div className="flex flex-col items-center">
+      <p className="text-center text-lg mb-4">
+        <span className="font-bold">{sendAt || '날짜를'}</span> 선택하고
+        타임캡슐을 보내세요!
+      </p>
+      <input
+        type="date"
+        value={sendAt}
+        onChange={(e) => setSendAt(e.target.value)}
+        min={new Date().toISOString().split('T')[0]} //과거 날짜 선택 못하도록 유효성 검사 추가
+        className="border px-3 py-2 rounded mb-6 w-full"
+        required
+      />
+      <button
+        type="button"
+        onClick={onNext}
+        className="bg-black text-white px-4 py-2 rounded w-full"
+        disabled={!sendAt}
+      >
+        다음으로
+      </button>
+    </div>
+  );
+};
+
+export default CalendarStep;

--- a/src/components/letterComponents/LetterForm.tsx
+++ b/src/components/letterComponents/LetterForm.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { getImageUrl, uploadImage } from '@/actions/storageActions';
 import browserClient from '@/app/utils/supabase/client';
-import Image from 'next/image';
 import { useState, useEffect } from 'react';
+import CalendarStep from './CalendarStep';
+import LetterStep from './LetterStep';
 
 const LetterForm = () => {
   //useState를 이용해 사용자가 입력한 값 상태관리
@@ -13,6 +13,7 @@ const LetterForm = () => {
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [message, setMessage] = useState('');
   const [userId, setUserId] = useState<string | null>(null);
+  const [step, setStep] = useState<'calendar' | 'letter'>('calendar');
 
   useEffect(() => {
     //로그인된 사용자 정보 가져오기
@@ -26,113 +27,41 @@ const LetterForm = () => {
         setUserId(user.id);
       } else {
         console.error('사용자 정보를 불러오는데 실패했습니다.', error);
+        setMessage('로그인 상태를 확인할 수 없습니다. 다시 로그인해주세요.');
       }
     };
     fetchUser();
   }, []);
 
-  // 이미지 파일 선택
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-
-    setImageFile(file);
-    const previewUrl = URL.createObjectURL(file);
-    setImagePreview(previewUrl);
-  };
-  //편지 제출 핸들러
-  const handleLetterSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-
-    if (!userId) {
-      setMessage('로그인 후 이용해주세요.');
-      return;
-    }
-
-    let imageUrl = '';
-
-    // 이미지가 선택된 경우 → Storage에 업로드하고 public URL 받기
-    if (imageFile) {
-      const rawFileName = `${Date.now()}_${imageFile.name}`;
-      //파일명 인코딩해서 한글이나 특수문자형식의 파일명도 쓸 수 있도록 처리
-      const encodedPath = `letters/${encodeURIComponent(rawFileName)}`;
-
-      // storage에 업로드할 데이터를 FormData로 구성
-      const formData = new FormData();
-      formData.append('file', imageFile);
-      formData.append('path', encodedPath);
-
-      try {
-        await uploadImage(formData);
-        imageUrl = getImageUrl(encodedPath); // 여기도 인코딩된 path 사용
-      } catch (error) {
-        console.error('이미지 업로드 실패:', error);
-        setMessage('이미지 업로드에 실패했습니다.');
-        return;
-      }
-    }
-    // letter 테이블에 데이터 저장하기
-    const { data, error } = await browserClient
-      .from('letter')
-      .insert([
-        { user_id: userId, content, send_at: sendAt, img_url: imageUrl }
-      ]);
-    if (error) {
-      console.error('편지 저장 실패', error);
-      setMessage('저장에 실패했습니다.');
-    } else {
-      console.log('저장된 편지 =>', data);
-      setMessage('편지를 저장했습니다!');
-      //저장 했으면 입력 필드 초기화
-      setContent('');
-      setSendAt('');
-      setImageFile(null);
-      setImagePreview(null);
-    }
-  };
   return (
-    <section>
+    <section className="max-w-sm mx-auto px-4 py-6">
       <header>
-        <h1>미래의 나에게 하고싶은 말을 작성해보세요!</h1>
+        <h1 className="text-xl font-semibold text-center mb-4">
+          미래의 나에게 하고싶은 말
+        </h1>
       </header>
+      {step === 'calendar' ? (
+        <CalendarStep
+          sendAt={sendAt}
+          setSendAt={setSendAt}
+          onNext={() => setStep('letter')}
+        />
+      ) : (
+        <LetterStep
+          sendAt={sendAt}
+          setSendAt={setSendAt}
+          content={content}
+          setContent={setContent}
+          imageFile={imageFile}
+          setImageFile={setImageFile}
+          imagePreview={imagePreview}
+          setImagePreview={setImagePreview}
+          onBack={() => setStep('calendar')}
+          setMessage={setMessage}
+          userId={userId}
+        />
+      )}
 
-      <form onSubmit={handleLetterSubmit}>
-        <article>
-          <label>날짜 선택</label>
-          <input
-            type="date"
-            value={sendAt}
-            onChange={(e) => setSendAt(e.target.value)}
-            required
-          />
-        </article>
-        <article>
-          <label>미래의 나에게 보내는 편지</label>
-          <textarea
-            value={content}
-            onChange={(e) => setContent(e.target.value)}
-            required
-            className="w-full border rounded px-3 py-2 h-32"
-          />
-        </article>
-        <article>
-          <input type="file" accept="image/*" onChange={handleImageChange} />
-          {imagePreview && (
-            <section className="mt-2">
-              <Image
-                src={imagePreview}
-                alt="이미지 미리보기"
-                width={200}
-                height={200}
-                className="object-cover"
-              />
-            </section>
-          )}
-        </article>
-        <button type="button" onClick={handleLetterSubmit}>
-          전송
-        </button>
-      </form>
       {message && (
         <p className="mt-4 text-center text-sm text-red-500">{message}</p>
       )}

--- a/src/components/letterComponents/LetterStep.tsx
+++ b/src/components/letterComponents/LetterStep.tsx
@@ -1,0 +1,141 @@
+import { getImageUrl, uploadImage } from '@/actions/storageActions';
+import browserClient from '@/app/utils/supabase/client';
+import Image from 'next/image';
+import React from 'react';
+
+type LetterStepProps = {
+  sendAt: string;
+  setSendAt: (date: string) => void;
+  content: string;
+  setContent: (val: string) => void;
+  imageFile: File | null;
+  setImageFile: (file: File | null) => void;
+  imagePreview: string | null;
+  setImagePreview: (url: string | null) => void;
+  onBack: () => void;
+  setMessage: (msg: string) => void;
+  userId: string | null;
+};
+
+const LetterStep = ({
+  sendAt,
+  setSendAt,
+  content,
+  setContent,
+  imageFile,
+  setImageFile,
+  imagePreview,
+  setImagePreview,
+  onBack,
+  setMessage,
+  userId
+}: LetterStepProps) => {
+  // 이미지 파일 선택
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setImageFile(file);
+    const previewUrl = URL.createObjectURL(file);
+    setImagePreview(previewUrl);
+  };
+  //편지 제출 핸들러
+  const handleLetterSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!userId) {
+      setMessage('로그인 후 이용해주세요.');
+      return;
+    }
+
+    let imageUrl = '';
+
+    // 이미지가 선택된 경우 → Storage에 업로드하고 public URL 받기
+    if (imageFile) {
+      const rawFileName = `${Date.now()}_${imageFile.name}`;
+      //파일명 인코딩해서 한글이나 특수문자형식의 파일명도 쓸 수 있도록 처리
+      const encodedPath = `letters/${encodeURIComponent(rawFileName)}`;
+
+      // storage에 업로드할 데이터를 FormData로 구성
+      const formData = new FormData();
+      formData.append('file', imageFile);
+      formData.append('path', encodedPath);
+
+      try {
+        await uploadImage(formData);
+        imageUrl = getImageUrl(encodedPath); // 여기도 인코딩된 path 사용
+      } catch (error) {
+        console.error('이미지 업로드 실패:', error);
+        setMessage('이미지 업로드에 실패했습니다.');
+        return;
+      }
+    }
+    // letter 테이블에 데이터 저장하기
+    const { data, error } = await browserClient
+      .from('letter')
+      .insert([
+        { user_id: userId, content, send_at: sendAt, img_url: imageUrl }
+      ]);
+    if (error) {
+      console.error('편지 저장 실패', error);
+      setMessage('저장에 실패했습니다.');
+    } else {
+      console.log('저장된 편지 =>', data);
+      setMessage('편지를 저장했습니다!');
+      //저장 했으면 입력 필드 초기화
+      setContent('');
+      setSendAt('');
+      setImageFile(null);
+      setImagePreview(null);
+      onBack();
+    }
+  };
+  return (
+    <form onSubmit={handleLetterSubmit} className="space-y-4">
+      <label className="block text-sm">미래의 나에게 보내는 편지 내용</label>
+      <textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        className="w-full border rounded px-3 py-2 h-32"
+        required
+      />
+
+      <label className="block text-sm">사진 선택</label>
+      <input
+        type="file"
+        accept="image/*"
+        onChange={handleImageChange}
+        className="w-full"
+      />
+      {imagePreview && (
+        <div className="mt-2">
+          <Image
+            src={imagePreview}
+            alt="미리보기"
+            width={200}
+            height={200}
+            className="object-cover"
+          />
+        </div>
+      )}
+
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={onBack}
+          className="border px-4 py-2 rounded w-1/2"
+        >
+          이전으로
+        </button>
+        <button
+          type="submit"
+          className="bg-black text-white px-4 py-2 rounded w-1/2"
+        >
+          편지 보내기
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default LetterStep;


### PR DESCRIPTION
💡 관련이슈


🍀 작업 요약
- CalendarStep, LetterStep 컴포넌트 추가하여 단계적으로 흐름이 이어지도록  조건부 렌더링(통계페이지 mode 기능 참고)
- LetterForm 컴포넌트 코드 정리 
- next.config.js 파일에서 images.domains 설정
- 달력에서 과거 날짜를 선택하지 못하도록 날짜 유효성 검사 추가
- 와이어프레임 모바일 시안 적용


💬 리뷰 요구 사항


💛 미리보기
<img width="334" alt="스크린샷 2025-04-09 오후 12 22 26" src="https://github.com/user-attachments/assets/50e65315-eb3c-41c0-b177-0fbdced0c71d" />
<img width="334" alt="스크린샷 2025-04-09 오후 12 22 50" src="https://github.com/user-attachments/assets/787813fc-76b0-4b31-9e6a-667d06dd92b6" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced image support by allowing images from an approved external source.
  - Introduced a two-step letter creation process: select a send date and then compose your letter with image upload capability.
  - Streamlined the letter page interface by removing an unnecessary header for a cleaner design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->