### PR TITLE
🩹 fix / NoteBox 페이지 min-h-screen 제거, 썸네일 경로 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,7 +32,7 @@ export default function RootLayout({
         />
         <meta property="og:title" content="DONT WORRY" />
         <meta property="og:description" content="당신의 걱정을 들어드릴게요" />
-        <meta property="og:image" content="Thumbnail.svg" />
+        <meta property="og:image" content="/images/Thumbnail.svg" />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
         {/*썸네일 이미지 넣기*/}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,7 +36,7 @@ export default function RootLayout({
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
         {/*썸네일 이미지 넣기*/}
-        <link rel="icon" href="/images/favicon.ico?v=1" />
+        <link rel="icon" href="/images/favicon.svg" />
         {/*파비콘 url 설정하기*/}
       </head>
       <body className={`${pretendard.className}`}>

--- a/src/app/note/page.tsx
+++ b/src/app/note/page.tsx
@@ -1,5 +1,4 @@
-// export const dynamic = 'force-dynamic';
-
+'use client';
 import StepFlow from '@/components/noteComponents/StepFlow';
 
 const NotePage = () => {

--- a/src/app/notebox/page.tsx
+++ b/src/app/notebox/page.tsx
@@ -107,7 +107,7 @@ const NotePage = () => {
     setIsEdit(false);
   };
   return (
-    <div className="w-full max-w-[375px] mx-auto min-h-screen bg-white flex flex-col">
+    <div className="w-full max-w-[375px] mx-auto pb-20 bg-backgroundSet-normal flex flex-col">
       <div className="flex justify-center items-center px-[6px] py-[15px]">
         <Text variant="title2" color="label-normal" className=" text-center">
           걱정 보관함
@@ -153,7 +153,7 @@ const NotePage = () => {
         />
       )}
 
-      <main className="flex-1 overflow-y-auto  px-5 py-2 space-y-4">
+      <main className="flex-1   px-5 py-2 space-y-4">
         {filteredNotes.map((note) => {
           const isChecked = selectedNoteIds.includes(note.note_id);
           return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-// export const dynamic = 'force-static';
+export const dynamic = 'force-static';
 
 import Image from 'next/image';
 import Text from '@/components/common/Text';
@@ -268,6 +268,7 @@ const HomePage = () => {
             width={335}
             height={300}
             alt="community"
+            quality={80}
           />
         </div>
       </section>

--- a/src/components/loginComponents/LoginProfile.tsx
+++ b/src/components/loginComponents/LoginProfile.tsx
@@ -15,7 +15,7 @@ import Link from 'next/link';
 
 const LoginProfile = () => {
   const { data: userData } = useUserInfo();
-  console.log('userData', userData);
+  // console.log('userData', userData);
   return (
     <div className="flex items-center gap-3">
       <div className="w-[32px] h-[32px] rounded-full overflow-hidden">

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -98,7 +98,7 @@ file_size_limit = "50MiB"
 # [storage.buckets.images]
 # public = false
 # file_size_limit = "50MiB"
-# allowed_mime_types = ["image/png", "image/jpeg"]
+# allowed_mime_types = ["image/png", "image/jpeg","image/svg"]
 # objects_path = "./images"
 
 [auth]


### PR DESCRIPTION
💡 관련이슈
현재의 이슈 번호 및 관련 있는 예전 이슈 번호를 넣어주세요.

🍀 작업 요약
한 작업에 대해 요약 정리해주세요.

💬 리뷰 요구 사항
의논하고 싶은 내용이 있다면 작성해주세요.

💛 미리보기
사진이나 gif 등 미리 볼 수 있는 파일을 제공해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **스타일**
  - 노트박스 페이지의 레이아웃과 배경색이 변경되고, 세로 스크롤이 제거되었습니다.
- **신규 기능**
  - 노트 페이지가 클라이언트 컴포넌트로 명시되었습니다.
- **버그 수정**
  - 소셜 미디어 미리보기 이미지의 경로가 절대 경로로 수정되었습니다.
  - 파비콘이 SVG 형식으로 변경되었습니다.
- **기타**
  - 메인 페이지의 이미지 품질이 개선되었으며, 동적 렌더링 관련 설정이 적용되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->