### PR TITLE
[CSS]Ranking/ 모발, 테블릿, 데스크탑 디자인 시안 적용 완료

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -61,7 +61,7 @@ export default function RootLayout({
         <link rel="icon" href="/images/favicon.svg" />
         {/*파비콘 url 설정하기*/}
       </head>
-      <body className={`${pretendard.className}`}>
+      <body className={`${pretendard.className} w-full max-w-[1280px] mx-auto`}>
         <Providers>
           <AuthProvider>
             <Header />

--- a/src/app/ranking/layout.tsx
+++ b/src/app/ranking/layout.tsx
@@ -29,7 +29,7 @@ const RankingLayout = ({
 }: Readonly<{ children: React.ReactNode }>) => {
   return (
     <div className="w-full flex justify-center">
-      <div className="xl:bg-backgroundSet-normal w-full max-w-[1280px] mx-auto">
+      <div className="xl:bg-backgroundSet-normal">
         {/*마지막 3개의 속성을 루트에서 적용시켜야함*/}
         <div className="pr-[6px] pl-[6px] h-14 flex items-center justify-center sticky top-0 z-10 bg-backgroundSet-normal">
           <Text

--- a/src/app/ranking/layout.tsx
+++ b/src/app/ranking/layout.tsx
@@ -31,7 +31,7 @@ const RankingLayout = ({
     <div className="w-full flex justify-center">
       <div className="xl:bg-backgroundSet-normal w-full max-w-[1280px] mx-auto">
         {/*마지막 3개의 속성을 루트에서 적용시켜야함*/}
-        <div className="pr-[6px] pl-[6px] h-14 flex items-center justify-center">
+        <div className="pr-[6px] pl-[6px] h-14 flex items-center justify-center sticky top-0 z-10 bg-backgroundSet-normal">
           <Text
             as="h1"
             variant="title1"

--- a/src/app/ranking/page.tsx
+++ b/src/app/ranking/page.tsx
@@ -133,11 +133,11 @@ const RankingPage = () => {
   }
 
   return (
-    <div className="bg-backgroundSet-card">
+    <div className="bg-backgroundSet-card md:px-[60px]">
       {/*레이아웃 상위*/}
       <div className="xl:flex xl:flex-row xl:bg-backgroundSet-card xl:px-[40px] xl:py-[40px] xl:gap-[40px] xl:items-center xl:justify-center">
-        <div className="p-4 xl:p-0">
-          <div className="flex flex-col items-center gap-[40px] px-[20px] py-[20px] xl:py-[40px] xl:px-[122px] xl:gap-[12px] self-stretch bg-backgroundSet-normal rounded-[20px] w-full xl:w-[580px] shadow-customCard">
+        <div className="p-5 xl:p-0 md:p-0">
+          <div className="flex flex-col items-center gap-[40px] px-[20px] py-[40px] xl:py-[30px] xl:px-[122px] xl:gap-[24px] self-stretch bg-backgroundSet-normal rounded-[20px] w-full xl:w-[580px] shadow-customCard xl:h-[500px] md:h-[481px]">
             {chartMode === 'topic' ? (
               <TopicChart topTopics={topTopics} />
             ) : (
@@ -146,11 +146,11 @@ const RankingPage = () => {
             <Report most={most} />
           </div>
         </div>
-        <div className="flex flex-col items-center gap-[20px] px-5 py-10 self-stretch xl:w-full xl:gap-[40px] xl:p-0 xl:max-w-[580px]">
+        <div className="flex flex-col items-center gap-[20px] px-5 py-10 self-stretch xl:w-full xl:gap-[40px] xl:p-0 xl:max-w-[580px] justify-center md:px-0">
           <FilterMenu />
 
           {chartMode === 'topic' ? (
-            <div className="flex flex-col w-full xl:w-[580px] gap-[12px]">
+            <div className="flex flex-col w-full xl:w-[580px] gap-[12px] xl:gap-[16px]">
               {topSixTopic.map((e) => (
                 <div key={e.name}>
                   <TopThreeCard topThree={e} />
@@ -158,7 +158,7 @@ const RankingPage = () => {
               ))}
             </div>
           ) : (
-            <div className="flex flex-col w-full max-w-full gap-[12px]">
+            <div className="flex flex-col w-full max-w-full gap-[12px] xl:gap-[16px]">
               {topSixEmotion.map((e) => (
                 <div key={e.name}>
                   <TopThreeCard topThree={e} />
@@ -171,15 +171,15 @@ const RankingPage = () => {
       {/*레이아웃 상위*/}
       {/*데스크탑 레이아웃 하위*/}
       <div className="xl:flex xl:flex-row xl:px-10 xl:pb-[40px] xl:justify-center xl:items-center xl:gap-[40px] xl:w-full xl:bg-backgroundSet-card">
-        <div className="p-4 xl:p-0 w-full ">
+        <div className="p-4 xl:p-0 w-full md:px-0">
           <MWreportCard />
         </div>
         {chartMode === 'topic' ? (
-          <div className="xl:flex xl:w-full p-4 xl:p-0 xl:max-w-[580px]">
+          <div className="xl:flex xl:w-full p-4 xl:p-0 xl:max-w-[580px] md:px-0">
             <Solution topThree={topSixTopic} />
           </div>
         ) : (
-          <div className="xl:flex xl:w-full p-4 xl:p-0">
+          <div className="xl:flex xl:w-full p-4 xl:p-0 md:px-0">
             <Solution topThree={topSixEmotion} />
           </div>
         )}

--- a/src/components/ranking/EmotionsChart.tsx
+++ b/src/components/ranking/EmotionsChart.tsx
@@ -74,7 +74,7 @@ const EmotionChart: React.FC<EmotionChartProps> = ({ topEmotions }) => {
 
   return (
     <>
-      <div className="flex w-[258px] flex-col items-center">
+      <div className="flex w-[258px] flex-col items-center gap-2">
         <Text
           as="h2"
           variant="heading3"
@@ -92,7 +92,7 @@ const EmotionChart: React.FC<EmotionChartProps> = ({ topEmotions }) => {
           {EMOTION_FILTER_DESCRIPTION2}
         </Text>
       </div>
-      <div className="w-[217.8px] h-[198px] xl:w-[280px] xl:h-[255px] flex justify-center items-center xl:gap-3">
+      <div className="w-[217.8px] h-[220px] xl:w-[255px] xl:h-[255px] flex justify-center items-center xl:gap-3">
         <Doughnut options={options} data={emotionChartData} />
       </div>
     </>

--- a/src/components/ranking/Solution.tsx
+++ b/src/components/ranking/Solution.tsx
@@ -150,7 +150,7 @@ const Solution = ({ topThree }: SolutionProps) => {
         <Text
           variant="body3"
           color="label-normal"
-          className="items-center flex w-full p-4 flex-col justify-center gap-2 rounded-lg bg-primary-1 whitespace-normal break-words xl:p-6 xl:w-max-[500px] xl:h-[240px]"
+          className="items-center flex w-full p-4 flex-col justify-center gap-2 rounded-lg bg-primary-1 whitespace-normal break-words xl:p-6 xl:max-w-[500px] xl:h-[240px]"
         >
           {solution}
         </Text>

--- a/src/components/ranking/TimeFilter.tsx
+++ b/src/components/ranking/TimeFilter.tsx
@@ -46,7 +46,7 @@ const TimeFilter = ({ type, options, onChange, selected }: Props) => {
             isNaN(+e.target.value) ? e.target.value : +e.target.value
           )
         }
-        className="appearance-none h-[32px] px-[16px] py-[6px] border border-line-noraml rounded-[16px] text-label-neutral focus:outline-none focus:ring-2 focus:bg-primary-3 pr-[32px] text-center"
+        className="appearance-none h-[32px] px-[16px] py-[6px] border border-line-normal rounded-[16px] text-label-neutral focus:outline-none focus:ring-2 focus:ring-primary-3 pr-[32px] text-center" //todo: 테두리색 변경
         style={{
           textAlignLast: 'center',
           textAlign: 'center',

--- a/src/components/ranking/TopicChart.tsx
+++ b/src/components/ranking/TopicChart.tsx
@@ -74,7 +74,7 @@ const TopicChart: React.FC<ChartProps> = ({ topTopics }) => {
 
   return (
     <>
-      <div className="flex w-[258px] flex-col items-center">
+      <div className="flex w-[258px] flex-col items-center gap-2">
         <Text
           as="h2"
           variant="heading3"
@@ -93,7 +93,7 @@ const TopicChart: React.FC<ChartProps> = ({ topTopics }) => {
         </Text>
       </div>
 
-      <div className="w-[217.8px] h-[220px] xl:w-[280px] xl:h-[255px] flex justify-center items-center xl:gap-3">
+      <div className="w-[217.8px] h-[220px] xl:w-[255px] xl:h-[255px] flex justify-center items-center xl:gap-3 md:w-[217.8px]">
         <Doughnut options={options} data={topicChartData} />
       </div>
     </>


### PR DESCRIPTION
🍀 작업 요약
1280이상 늘어나지 않게 css가 추가됬습니다


💛 미리보기
<img width="1147" alt="스크린샷 2025-04-23 오후 7 04 36" src="https://github.com/user-attachments/assets/024314cf-3c8f-4d8a-87be-517cfb5a1494" />

<img width="955" alt="스크린샷 2025-04-23 오후 7 04 43" src="https://github.com/user-attachments/assets/c208534a-4107-4346-a194-5714f4222db5" />

<img width="559" alt="스크린샷 2025-04-23 오후 7 04 52" src="https://github.com/user-attachments/assets/25c5752e-1310-4d0c-b9c6-af4fc4357a7b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - 랭킹 페이지의 제목 바가 상단에 고정되어 항상 보이도록 개선되었습니다.
  - 다양한 화면 크기에서 랭킹 페이지의 여백, 간격, 높이 등이 조정되어 레이아웃과 반응형 디자인이 향상되었습니다.
  - 감정 차트와 주제 차트의 간격 및 크기가 조정되어 시각적 일관성이 높아졌습니다.
  - 기간 필터의 테두리 색상 및 포커스 효과가 올바르게 표시되도록 수정되었습니다.
  - 전체 레이아웃 최대 너비가 1280px로 제한되고 중앙 정렬되어 콘텐츠 가독성이 개선되었습니다.
  - 일부 텍스트 컴포넌트의 최대 너비 스타일이 올바르게 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->